### PR TITLE
fix: swagger dto 컴포넌트 문제 해결

### DIFF
--- a/src/main/java/alkong_dalkong/backend/Medical/config/SwaggerConfig.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/config/SwaggerConfig.java
@@ -46,10 +46,11 @@ public class SwaggerConfig {
         FilterChainProxy filterChainProxy = applicationContext
                 .getBean(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME, FilterChainProxy.class);
         return openAPI -> {
-            openAPI.components(new Components())
-                    .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
-                    .security(Arrays.asList(securityRequirement))
+            Components components = openAPI.getComponents();
+            components.addSecuritySchemes("bearerAuth", securityScheme);
+            openAPI.security(Arrays.asList(securityRequirement))
                     .info(apiInfo());
+
             for (SecurityFilterChain filterChain : filterChainProxy.getFilterChains()) {
                 Optional<LoginFilter> optionalLoginFilter = filterChain.getFilters().stream()
                         .filter(LoginFilter.class::isInstance)


### PR DESCRIPTION
1. customSpringSecurityLoginEndpointCustomiser에서 openAPI의 getComponent()를 통해 자동으로 가져와 문제 해결

close #32 