### PR TITLE
feat: 진료 정보 추가 기능 구현

### DIFF
--- a/src/main/java/alkong_dalkong/backend/Medical/controller/MedicalController.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/controller/MedicalController.java
@@ -1,7 +1,7 @@
 package alkong_dalkong.backend.Medical.controller;
 
 import alkong_dalkong.backend.Medical.dto.response.DetailMedicalResponseDto;
-import alkong_dalkong.backend.Medical.service.DetailMedicalService;
+import alkong_dalkong.backend.Medical.service.MedicalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,16 +14,16 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/medical")
-public class DetailMedicalController {
+public class MedicalController {
 
     @Autowired
-    private DetailMedicalService detailMedicalService;
+    private MedicalService medicalService;
 
     @GetMapping("/{medical_id}")
     public ResponseEntity<?> getDetailMedicalInfo(@PathVariable("medical_id") Long medicalId) {
 
         try {
-            DetailMedicalResponseDto data = detailMedicalService.getMedicalDetail(medicalId);
+            DetailMedicalResponseDto data = medicalService.getMedicalDetail(medicalId);
 
             return ResponseEntity.ok().body(Map.of("code", 200, "data", data));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/alkong_dalkong/backend/Medical/controller/MedicalController.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/controller/MedicalController.java
@@ -1,14 +1,12 @@
 package alkong_dalkong.backend.Medical.controller;
 
+import alkong_dalkong.backend.Medical.dto.request.MedicalRequestDto;
 import alkong_dalkong.backend.Medical.dto.response.DetailMedicalResponseDto;
 import alkong_dalkong.backend.Medical.service.MedicalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -26,6 +24,19 @@ public class MedicalController {
             DetailMedicalResponseDto data = medicalService.getMedicalDetail(medicalId);
 
             return ResponseEntity.ok().body(Map.of("code", 200, "data", data));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("code", 400, "error", "잘못된 입력값 제공"));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("code", 500, "error", "예상치 못한 오류 발생"));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<?> setDetailMedicalInfo(@RequestBody MedicalRequestDto requestDto) {
+        try {
+            Long medicalId = medicalService.setMedicalInfo(requestDto);
+
+            return ResponseEntity.ok().body(Map.of("code", 200, "medical_id", medicalId));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("code", 400, "error", "잘못된 입력값 제공"));
         } catch (Exception e) {

--- a/src/main/java/alkong_dalkong/backend/Medical/dto/request/MedicalRequestDto.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/dto/request/MedicalRequestDto.java
@@ -1,0 +1,27 @@
+package alkong_dalkong.backend.Medical.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MedicalRequestDto {
+
+    private Long userId;
+    private String hospitalName;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime hospitalDate;
+
+    private List<String> medicalPart;
+    private String medicalMemo;
+    private int medicalAlarm;
+}

--- a/src/main/java/alkong_dalkong/backend/Medical/entity/MedicalInfo.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/entity/MedicalInfo.java
@@ -2,16 +2,14 @@ package alkong_dalkong.backend.Medical.entity;
 
 import alkong_dalkong.backend.Medical.common.StringListConverter;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "medicalinfo")
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/alkong_dalkong/backend/Medical/repository/UsersRepository.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/repository/UsersRepository.java
@@ -1,0 +1,8 @@
+package alkong_dalkong.backend.Medical.repository;
+
+import alkong_dalkong.backend.Medical.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+
+}

--- a/src/main/java/alkong_dalkong/backend/Medical/service/MedicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/service/MedicalService.java
@@ -16,6 +16,7 @@ public class MedicalService {
     @Autowired
     private MedicalInfoRepository medicalInfoRepository;
 
+    /* 진료 정보 get */
     public DetailMedicalResponseDto getMedicalDetail(Long medicalId) {
         Optional<MedicalInfo> optionalMedicalInfo = medicalInfoRepository.findById(medicalId);
 
@@ -38,6 +39,7 @@ public class MedicalService {
 
     }
 
+    /* 알람 인덱스 계산 */
     private int calculateAlarmIndex(LocalDateTime hospitalDate, LocalDateTime medicalAlarm) {
         if (medicalAlarm == null) {
             return 5;
@@ -58,5 +60,17 @@ public class MedicalService {
         }
 
         return 5; // 모두 해당하지 않는 경우 -> 추후 예외처리 필요
+    }
+
+    /* 알람 시간 계산 */
+    private LocalDateTime calculateAlarmDate(LocalDateTime hospitalDate, int medicalAlarmIndex) {
+        return switch (medicalAlarmIndex) {
+            case 0 -> hospitalDate.minusDays(7);
+            case 1 -> hospitalDate.minusHours(24);
+            case 2 -> hospitalDate.minusHours(12);
+            case 3 -> hospitalDate.minusHours(1);
+            case 4 -> hospitalDate.minusMinutes(30);
+            default -> null; // case 5
+        };
     }
 }

--- a/src/main/java/alkong_dalkong/backend/Medical/service/MedicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/service/MedicalService.java
@@ -1,8 +1,11 @@
 package alkong_dalkong.backend.Medical.service;
 
+import alkong_dalkong.backend.Medical.dto.request.MedicalRequestDto;
 import alkong_dalkong.backend.Medical.dto.response.DetailMedicalResponseDto;
 import alkong_dalkong.backend.Medical.entity.MedicalInfo;
+import alkong_dalkong.backend.Medical.entity.Users;
 import alkong_dalkong.backend.Medical.repository.MedicalInfoRepository;
+import alkong_dalkong.backend.Medical.repository.UsersRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +18,9 @@ public class MedicalService {
 
     @Autowired
     private MedicalInfoRepository medicalInfoRepository;
+
+    @Autowired
+    private UsersRepository usersRepository;
 
     /* 진료 정보 get */
     public DetailMedicalResponseDto getMedicalDetail(Long medicalId) {
@@ -37,6 +43,26 @@ public class MedicalService {
             return null;
         }
 
+    }
+
+    /* 진료 정보 post */
+    public Long setMedicalInfo(MedicalRequestDto requestDto) {
+        Users user = usersRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+        LocalDateTime medicalAlarm = calculateAlarmDate(requestDto.getHospitalDate(), requestDto.getMedicalAlarm());
+
+        MedicalInfo medicalInfo = new MedicalInfo();
+        medicalInfo.setUser(user);
+        medicalInfo.setHospitalName(requestDto.getHospitalName());
+        medicalInfo.setHospitalDate(requestDto.getHospitalDate());
+        medicalInfo.setMedicalPart(requestDto.getMedicalPart());
+        medicalInfo.setMedicalMemo(requestDto.getMedicalMemo());
+        medicalInfo.setMedicalAlarm(medicalAlarm);
+
+        medicalInfo = medicalInfoRepository.save(medicalInfo);
+
+        return medicalInfo.getMedicalId();
     }
 
     /* 알람 인덱스 계산 */

--- a/src/main/java/alkong_dalkong/backend/Medical/service/MedicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Medical/service/MedicalService.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
-public class DetailMedicalService {
+public class MedicalService {
 
     @Autowired
     private MedicalInfoRepository medicalInfoRepository;


### PR DESCRIPTION
1. post 요청: 진료 정보 세부 내용 추가 기능 구현
2.  알람 인덱스에 맞게 db상에 datetime 형식으로 저장
3. 입력 받을 때 yyyy-MM-dd HH:mm:ss 형식으로 받도록 dto에서 지

close #34 