### PR TITLE
feat: 건강 정보 페이지 get 기능 구현

### DIFF
--- a/src/main/java/alkong_dalkong/backend/Physical/controller/PhysicalController.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/controller/PhysicalController.java
@@ -1,0 +1,31 @@
+package alkong_dalkong.backend.Physical.controller;
+
+import alkong_dalkong.backend.Physical.dto.response.PhysicalResponseDto;
+import alkong_dalkong.backend.Physical.service.PhysicalService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/physical")
+public class PhysicalController {
+
+    @Autowired
+    private PhysicalService physicalService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> getPhysicalInfo(@PathVariable Long userId, @RequestParam String period) {
+        try {
+            PhysicalResponseDto data = physicalService.getPhysicalInfo(userId, period);
+            return ResponseEntity.ok().body(Map.of("code", 200, "period", period, "data", data));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("code", 400, "error", e.getMessage()));
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("code", 500, "error", e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/dto/response/PhysicalResponseDto.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/dto/response/PhysicalResponseDto.java
@@ -1,0 +1,43 @@
+package alkong_dalkong.backend.Physical.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class PhysicalResponseDto {
+
+    private Long physicalId;
+    private Weight weight;
+    private List<WeightInfoDto> weightInfo;
+    private HealthReport healthReport;
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class Weight {
+        private Long weightId;
+        private float weight;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class WeightInfoDto {
+        private float avgWeight;
+        private String avgDate; // yyyy-MM 형식 / 주차별일땐 yyyy-MM-Wx 형식
+    }
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class HealthReport {
+        private float apiAvgWeight;
+        private float diffWeight;
+        private float lastweekWeight;
+    }
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/entity/PhysicalInfo.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/entity/PhysicalInfo.java
@@ -1,0 +1,29 @@
+package alkong_dalkong.backend.Physical.entity;
+
+import alkong_dalkong.backend.User.Domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhysicalInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long physicalId;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "physicalInfo", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<WeightInfo> weightInfoList = new ArrayList<>();
+
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/entity/WeightInfo.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/entity/WeightInfo.java
@@ -1,0 +1,28 @@
+package alkong_dalkong.backend.Physical.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WeightInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long weightId;
+
+    private float weight;
+
+    private LocalDate createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "physical_id")
+    private PhysicalInfo physicalInfo;
+
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/repository/PhysicalInfoRepository.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/repository/PhysicalInfoRepository.java
@@ -1,0 +1,10 @@
+package alkong_dalkong.backend.Physical.repository;
+
+import alkong_dalkong.backend.Physical.entity.PhysicalInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PhysicalInfoRepository extends JpaRepository<PhysicalInfo, Long> {
+    Optional<PhysicalInfo> findByUserUserId(Long userId);
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/repository/WeightInfoRepository.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/repository/WeightInfoRepository.java
@@ -1,0 +1,7 @@
+package alkong_dalkong.backend.Physical.repository;
+
+import alkong_dalkong.backend.Physical.entity.WeightInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeightInfoRepository  extends JpaRepository<WeightInfo, Long> {
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -45,8 +45,9 @@ public class PhysicalService {
 
         float apiAvgWeight = getApiAvgWeight(user.getGender(), user.getBirth());
 
-        Optional<WeightInfo> latestWeightOpt =
-                physicalInfo.getWeightInfoList().stream().findFirst();
+        // 체중 정보가 있는지 확인
+        Optional<WeightInfo> latestWeightOpt = physicalInfo.getWeightInfoList() != null ?
+                physicalInfo.getWeightInfoList().stream().findFirst() : Optional.empty();
 
         PhysicalResponseDto.Weight weightDto = null;
         if (latestWeightOpt.isPresent()) {
@@ -58,13 +59,14 @@ public class PhysicalService {
         }
 
         // 주기(period)에 따라 체중 데이터의 평균 계산
-        List<PhysicalResponseDto.WeightInfoDto> weightInfoDtoList = calculateAverageWeight(physicalInfo.getWeightInfoList(), period);
+        List<WeightInfo> weightInfoList = physicalInfo.getWeightInfoList() != null ? physicalInfo.getWeightInfoList() : Collections.emptyList();
+        List<PhysicalResponseDto.WeightInfoDto> weightInfoDtoList = calculateAverageWeight(weightInfoList, period);
 
         // 건강 리포트 생성 (체중 정보가 있을 때만 계산)
         PhysicalResponseDto.HealthReport healthReport = null;
         if (latestWeightOpt.isPresent()) {
             // 주별 그룹화된 weightInfoList를 넘김
-            healthReport = createHealthReport(latestWeightOpt.get().getWeight(), apiAvgWeight, calculateAverageWeight(physicalInfo.getWeightInfoList(), "weekly"));
+            healthReport = createHealthReport(latestWeightOpt.get().getWeight(), apiAvgWeight, calculateAverageWeight(weightInfoList, "weekly"));
         }
 
         return PhysicalResponseDto.builder()

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -91,6 +91,7 @@ public class PhysicalService {
                             calculateAverage(entry.getValue()), // 평균 계산
                             entry.getKey()  // 년-월-주차 정보
                     ))
+                    .sorted((a, b) -> b.getAvgDate().compareTo(a.getAvgDate())) // 년-월-주차 내림차순 정렬
                     .collect(Collectors.toList());
         } else if (period.equals("monthly")) {
             return weightInfoList.stream()
@@ -100,6 +101,7 @@ public class PhysicalService {
                             calculateAverage(entry.getValue()), // 평균 계산
                             entry.getKey().format(formatter)
                     ))
+                    .sorted((a, b) -> b.getAvgDate().compareTo(a.getAvgDate())) // 년-월 내림차순 정렬
                     .collect(Collectors.toList());
         }
         return Collections.emptyList();  // weightInfoList가 없으면 빈 리스트 반환

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -4,6 +4,7 @@ import alkong_dalkong.backend.Physical.dto.response.PhysicalResponseDto;
 import alkong_dalkong.backend.Physical.entity.PhysicalInfo;
 import alkong_dalkong.backend.Physical.entity.WeightInfo;
 import alkong_dalkong.backend.Physical.repository.PhysicalInfoRepository;
+import alkong_dalkong.backend.Physical.util.AgeRangeUtils;
 import alkong_dalkong.backend.Physical.util.ApiWeightData;
 import alkong_dalkong.backend.Physical.util.ApiWeightDataWrapper;
 import alkong_dalkong.backend.User.Domain.Gender;

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
@@ -112,4 +113,12 @@ public class PhysicalService {
         return (float) weightInfos.stream().mapToDouble(WeightInfo::getWeight).average().orElse(0);
     }
 
+    // WeightInfo 객체의 주(week) 계산후 문자열 조합 후 반환
+    private String getWeekOfMonthAndYear(WeightInfo weightInfo) {
+        LocalDate date = weightInfo.getCreatedAt();
+        // 해당 달의 몇 번째 주인지 계산 (1부터 시작)
+        int weekOfMonth = (date.getDayOfMonth() - 1) / 7 + 1;
+        // 년, 월, 주차 정보를 문자열로 반환
+        return date.getYear() + "-" + date.getMonthValue() + "-W" + weekOfMonth;
+    }
 }

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -32,8 +32,16 @@ public class PhysicalService {
         }
         User user = userOpt.get();
 
+        // 유저의 PhysicalInfo 찾기 (없으면 생성)
         Optional<PhysicalInfo> physicalInfoOpt = physicalInfoRepository.findByUserUserId(userId);
-        PhysicalInfo physicalInfo = physicalInfoOpt.get();
+        PhysicalInfo physicalInfo;
+        if (physicalInfoOpt.isEmpty()) {
+            physicalInfo = new PhysicalInfo();
+            physicalInfo.setUser(user);
+            physicalInfo = physicalInfoRepository.save(physicalInfo);
+        } else {
+            physicalInfo = physicalInfoOpt.get();
+        }
 
         float apiAvgWeight = getApiAvgWeight(user.getGender(), user.getBirth());
 

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -106,4 +106,10 @@ public class PhysicalService {
         }
         return Collections.emptyList();  // weightInfoList가 없으면 빈 리스트 반환
     }
+
+    // 리스트 내의 체중 정보 평균 계산
+    private float calculateAverage(List<WeightInfo> weightInfos) {
+        return (float) weightInfos.stream().mapToDouble(WeightInfo::getWeight).average().orElse(0);
+    }
+
 }

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -121,4 +121,20 @@ public class PhysicalService {
         // 년, 월, 주차 정보를 문자열로 반환
         return date.getYear() + "-" + date.getMonthValue() + "-W" + weekOfMonth;
     }
+
+    // 건강 리포트 생성
+    private PhysicalResponseDto.HealthReport createHealthReport(float latestWeight, float apiAvgWeight, List<PhysicalResponseDto.WeightInfoDto> weightInfoList) {
+        // 지난주 평균 체중 계산 (가장 최근 두 주를 비교)
+        float lastWeekAvgWeight = 0.0f;
+        if (weightInfoList.size() >= 2) {
+            // 최근 두 주차 중에서 두 번째 최신 주의 체중 평균을 선택
+            lastWeekAvgWeight = weightInfoList.get(1).getAvgWeight();
+        }
+
+        return PhysicalResponseDto.HealthReport.builder()
+                .apiAvgWeight(apiAvgWeight)
+                .diffWeight(latestWeight - apiAvgWeight)
+                .lastweekWeight(latestWeight - lastWeekAvgWeight)
+                .build();
+    }
 }

--- a/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/service/PhysicalService.java
@@ -1,0 +1,69 @@
+package alkong_dalkong.backend.Physical.service;
+
+import alkong_dalkong.backend.Physical.dto.response.PhysicalResponseDto;
+import alkong_dalkong.backend.Physical.entity.PhysicalInfo;
+import alkong_dalkong.backend.Physical.entity.WeightInfo;
+import alkong_dalkong.backend.Physical.repository.PhysicalInfoRepository;
+import alkong_dalkong.backend.User.Domain.User;
+import alkong_dalkong.backend.User.Repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PhysicalService {
+
+    @Autowired
+    private PhysicalInfoRepository physicalInfoRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private static final String WEIGHT_DATA_PATH = "src/main/resources/weight_data.json";
+
+    public PhysicalResponseDto getPhysicalInfo(Long userId, String period) throws IOException {
+        Optional<User> userOpt = userRepository.findById(userId);
+        if (userOpt.isEmpty()) {
+            throw new IllegalArgumentException("해당 유저를 찾을 수 없습니다: " + userId);
+        }
+        User user = userOpt.get();
+
+        Optional<PhysicalInfo> physicalInfoOpt = physicalInfoRepository.findByUserUserId(userId);
+        PhysicalInfo physicalInfo = physicalInfoOpt.get();
+
+        float apiAvgWeight = getApiAvgWeight(user.getGender(), user.getBirth());
+
+        Optional<WeightInfo> latestWeightOpt =
+                physicalInfo.getWeightInfoList().stream().findFirst();
+
+        PhysicalResponseDto.Weight weightDto = null;
+        if (latestWeightOpt.isPresent()) {
+            WeightInfo latestWeight = latestWeightOpt.get();
+            weightDto = PhysicalResponseDto.Weight.builder()
+                    .weightId(latestWeight.getWeightId())
+                    .weight(latestWeight.getWeight())
+                    .build();
+        }
+
+        // 주기(period)에 따라 체중 데이터의 평균 계산
+        List<PhysicalResponseDto.WeightInfoDto> weightInfoDtoList = calculateAverageWeight(physicalInfo.getWeightInfoList(), period);
+
+        // 건강 리포트 생성 (체중 정보가 있을 때만 계산)
+        PhysicalResponseDto.HealthReport healthReport = null;
+        if (latestWeightOpt.isPresent()) {
+            // 주별 그룹화된 weightInfoList를 넘김
+            healthReport = createHealthReport(latestWeightOpt.get().getWeight(), apiAvgWeight, calculateAverageWeight(physicalInfo.getWeightInfoList(), "weekly"));
+        }
+
+        return PhysicalResponseDto.builder()
+                .physicalId(physicalInfo.getPhysicalId())
+                .weight(weightDto)
+                .weightInfo(weightInfoDtoList)
+                .healthReport(healthReport)
+                .build();
+    }
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/util/AgeRangeUtils.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/util/AgeRangeUtils.java
@@ -1,0 +1,23 @@
+package alkong_dalkong.backend.Physical.util;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+public class AgeRangeUtils {
+
+    // 유저의 생년월일로 만나이 계산
+    public static int calculateAge(LocalDate birthDate, LocalDate currentDate) {
+        if (birthDate != null && currentDate != null) {
+            // 연도 차이를 먼저 계산
+            int age = Period.between(birthDate, currentDate).getYears();
+
+            // 생일이 지났는지 여부를 확인 (생일이 지나지 않았다면 나이를 1 줄임)
+            if (currentDate.getMonthValue() < birthDate.getMonthValue() ||
+                    (currentDate.getMonthValue() == birthDate.getMonthValue() && currentDate.getDayOfMonth() < birthDate.getDayOfMonth())) {
+                age--;
+            }
+            return age;
+        }
+        return 0;
+    }
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/util/ApiWeightData.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/util/ApiWeightData.java
@@ -1,0 +1,13 @@
+package alkong_dalkong.backend.Physical.util;
+
+import lombok.Data;
+
+@Data
+public class ApiWeightData {
+
+    private String gender;
+    private int minAge;
+    private int maxAge;
+    private float apiAvgWeight;
+
+}

--- a/src/main/java/alkong_dalkong/backend/Physical/util/ApiWeightDataWrapper.java
+++ b/src/main/java/alkong_dalkong/backend/Physical/util/ApiWeightDataWrapper.java
@@ -1,0 +1,31 @@
+package alkong_dalkong.backend.Physical.util;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ApiWeightDataWrapper {
+
+    private Metadata metadata;
+    private List<ApiWeightData> data;
+
+    @Data
+    public static class Metadata {
+        private String statisticsSource;
+        private AgeRanges ageRanges;
+
+        @Data
+        public static class AgeRanges {
+            @JsonProperty("6~18")
+            private String range6To18;
+
+            @JsonProperty("19~69")
+            private String range19To69;
+
+            @JsonProperty("70+")
+            private String range70Plus;
+        }
+    }
+}

--- a/src/main/java/alkong_dalkong/backend/User/Domain/User.java
+++ b/src/main/java/alkong_dalkong/backend/User/Domain/User.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.ArrayList;
 
+import alkong_dalkong.backend.Physical.entity.PhysicalInfo;
+import jakarta.persistence.*;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -13,15 +15,6 @@ import alkong_dalkong.backend.User.Dto.Request.UserInfoRequestDto;
 
 import org.springframework.security.core.GrantedAuthority;
 
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -65,6 +58,9 @@ public class User implements UserDetails {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Relationship> relationships;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private PhysicalInfo physicalInfo;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/resources/weight_data.json
+++ b/src/main/resources/weight_data.json
@@ -1,0 +1,324 @@
+{
+    "metadata": {
+        "statisticsSource": "KOSIS",
+        "ageRanges": {
+            "6~18": "한국교육개발원, 교육통계연보 (2020)",
+            "19~69": "산업통상자원부 국가기술표준원(2022)",
+            "70+": "국민건강보험공단(2024)"
+        }
+    },
+    "data": [
+        {
+            "gender": "MAN",
+            "minAge": 6,
+            "maxAge": 6,
+            "apiAvgWeight": 24.7
+        },
+        {
+            "gender": "MAN",
+            "minAge": 7,
+            "maxAge": 7,
+            "apiAvgWeight": 27.7
+        },
+        {
+            "gender": "MAN",
+            "minAge": 8,
+            "maxAge": 8,
+            "apiAvgWeight": 31.9
+        },
+        {
+            "gender": "MAN",
+            "minAge": 9,
+            "maxAge": 9,
+            "apiAvgWeight": 36.3
+        },
+        {
+            "gender": "MAN",
+            "minAge": 10,
+            "maxAge": 10,
+            "apiAvgWeight": 41.3
+        },
+        {
+            "gender": "MAN",
+            "minAge": 11,
+            "maxAge": 11,
+            "apiAvgWeight": 46.9
+        },
+        {
+            "gender": "MAN",
+            "minAge": 12,
+            "maxAge": 12,
+            "apiAvgWeight": 53.0
+        },
+        {
+            "gender": "MAN",
+            "minAge": 13,
+            "maxAge": 13,
+            "apiAvgWeight": 59.0
+        },
+        {
+            "gender": "MAN",
+            "minAge": 14,
+            "maxAge": 14,
+            "apiAvgWeight": 64.2
+        },
+        {
+            "gender": "MAN",
+            "minAge": 15,
+            "maxAge": 15,
+            "apiAvgWeight": 67.3
+        },
+        {
+            "gender": "MAN",
+            "minAge": 16,
+            "maxAge": 16,
+            "apiAvgWeight": 69.6
+        },
+        {
+            "gender": "MAN",
+            "minAge": 17,
+            "maxAge": 17,
+            "apiAvgWeight": 70.9
+        },
+        {
+            "gender": "MAN",
+            "minAge": 18,
+            "maxAge": 18,
+            "apiAvgWeight": 71.4
+        },
+        {
+            "gender": "MAN",
+            "minAge": 19,
+            "maxAge": 19,
+            "apiAvgWeight": 74.76
+        },
+        {
+            "gender": "MAN",
+            "minAge": 20,
+            "maxAge": 24,
+            "apiAvgWeight": 72.86
+        },
+        {
+            "gender": "MAN",
+            "minAge": 25,
+            "maxAge": 29,
+            "apiAvgWeight": 74.5
+        },
+        {
+            "gender": "MAN",
+            "minAge": 30,
+            "maxAge": 34,
+            "apiAvgWeight": 77.73
+        },
+        {
+            "gender": "MAN",
+            "minAge": 35,
+            "maxAge": 39,
+            "apiAvgWeight": 79.23
+        },
+        {
+            "gender": "MAN",
+            "minAge": 40,
+            "maxAge": 44,
+            "apiAvgWeight": 77.66
+        },
+        {
+            "gender": "MAN",
+            "minAge": 45,
+            "maxAge": 49,
+            "apiAvgWeight": 75.81
+        },
+        {
+            "gender": "MAN",
+            "minAge": 50,
+            "maxAge": 54,
+            "apiAvgWeight": 73.5
+        },
+        {
+            "gender": "MAN",
+            "minAge": 55,
+            "maxAge": 59,
+            "apiAvgWeight": 72.44
+        },
+        {
+            "gender": "MAN",
+            "minAge": 60,
+            "maxAge": 64,
+            "apiAvgWeight": 72.05
+        },
+        {
+            "gender": "MAN",
+            "minAge": 65,
+            "maxAge": 69,
+            "apiAvgWeight": 68.98
+        },
+        {
+            "gender": "MAN",
+            "minAge": 70,
+            "maxAge": 79,
+            "apiAvgWeight": 66.6
+        },
+        {
+            "gender": "MAN",
+            "minAge": 80,
+            "maxAge": 200,
+            "apiAvgWeight": 63.26
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 6,
+            "maxAge": 6,
+            "apiAvgWeight": 23.4
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 7,
+            "maxAge": 7,
+            "apiAvgWeight": 26.2
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 8,
+            "maxAge": 8,
+            "apiAvgWeight": 29.8
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 9,
+            "maxAge": 9,
+            "apiAvgWeight": 33.9
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 10,
+            "maxAge": 10,
+            "apiAvgWeight": 39.0
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 11,
+            "maxAge": 11,
+            "apiAvgWeight": 44.3
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 12,
+            "maxAge": 12,
+            "apiAvgWeight": 49.1
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 13,
+            "maxAge": 13,
+            "apiAvgWeight": 52.9
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 14,
+            "maxAge": 14,
+            "apiAvgWeight": 54.9
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 15,
+            "maxAge": 15,
+            "apiAvgWeight": 56.6
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 16,
+            "maxAge": 16,
+            "apiAvgWeight": 57.6
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 17,
+            "maxAge": 17,
+            "apiAvgWeight": 58.3
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 18,
+            "maxAge": 18,
+            "apiAvgWeight": 57.8
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 19,
+            "maxAge": 19,
+            "apiAvgWeight": 59.81
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 20,
+            "maxAge": 24,
+            "apiAvgWeight": 55.25
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 25,
+            "maxAge": 29,
+            "apiAvgWeight": 57.04
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 30,
+            "maxAge": 34,
+            "apiAvgWeight": 57.49
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 35,
+            "maxAge": 39,
+            "apiAvgWeight": 58.17
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 40,
+            "maxAge": 44,
+            "apiAvgWeight": 59.32
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 45,
+            "maxAge": 49,
+            "apiAvgWeight": 60.17
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 50,
+            "maxAge": 54,
+            "apiAvgWeight": 59.03
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 55,
+            "maxAge": 59,
+            "apiAvgWeight": 58.13
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 60,
+            "maxAge": 64,
+            "apiAvgWeight": 58.03
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 65,
+            "maxAge": 69,
+            "apiAvgWeight": 57.82
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 70,
+            "maxAge": 79,
+            "apiAvgWeight": 57.23
+        },
+        {
+            "gender": "WOMAN",
+            "minAge": 80,
+            "maxAge": 200,
+            "apiAvgWeight": 53.54
+        }
+    ]
+}


### PR DESCRIPTION
1. 오늘의 체중 정보
2. 주간/월간 평균 체중 리스트
3. 건강 리포트 기능
4. 통계 데이터는 양이 적기때문에 openapi 대신 직접 json 파일을 만들어서 사용

close #66 